### PR TITLE
feat: drag-select + reliable link import + New Download dialog refresh (1.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.11.0] - 2026-06-28
+
+### ✨ New Features
+
+**Drag-to-Select in the Downloads List**
+- Draw a selection box by dragging across empty space in the list to select multiple downloads at once — works in every view (All Downloads, a queue, or a category)
+- Hold **Shift** while dragging to add the boxed items to your existing selection instead of replacing it
+- The list auto-scrolls when you drag near the top or bottom edge, so you can select more than fits on screen
+- New keyboard shortcuts in the list: **Ctrl/Cmd + A** selects everything in the current view, **Esc** clears the selection
+
+**Smarter Link Importing**
+- Drag-and-drop, paste, and the browser extension now share one consistent import path
+- Pasting a multi-link selection (for example, a GitHub release asset list) now picks up every link, even when the links are hidden behind file names
+- Dropping or pasting a link while the New Download or Batch Import dialog is already open now fills it in, instead of being silently ignored
+- A drop that contains no links now shows a clear "No URLs found" message instead of doing nothing
+
+**Refreshed New Download Dialog**
+- Cleaner layout with a clearer header, a larger URL field, and a tidy detected-file card
+- You can start a download right away without waiting for the file details to load — the size is detected in the background
+
+### 🐛 Bug Fixes
+- Fixed links being ignored when dropped onto the app while a download dialog was already open (the field stayed empty)
+- Fixed inconsistent behavior where dragging selected links sometimes failed to open the import dialog
+
 ## [1.10.0] - 2026-06-28
 
 ### ✨ New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 authors = ["DLMan Contributors"]
 license = "MIT"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlman/desktop",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DLMan",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "identifier": "com.dlman.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -22,12 +22,12 @@ import { useSettingsStore, loadSettingsFromBackend } from "@/stores/settings";
 import { useUIStore } from "@/stores/ui";
 import { useDownloadStore } from "@/stores/downloads";
 import { loadCredentialsFromBackend } from "@/stores/credentials";
-import { setupEventListeners, setPendingClipboardUrls, setPendingDropUrls } from "@/lib/events";
+import { setupEventListeners } from "@/lib/events";
+import { ingestDroppedUrls, ingestPastedUrls, extractUrlsFromDataTransfer } from "@/lib/url-intake";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useUpdateCheck } from "@/hooks/useUpdateCheck";
 import { useApplyLocale } from "@/i18n/useApplyLocale";
 import { useTranslation } from "react-i18next";
-import { parseUrls } from "@/lib/utils";
 import { initSystemIntegrations } from "@/lib/system-tray";
 import { initNotifications } from "@/lib/notifications";
 
@@ -38,7 +38,7 @@ function AppContent() {
   const theme = useSettingsStore((s) => s.settings.theme);
   const defaultDownloadPath = useSettingsStore((s) => s.settings.default_download_path);
   const setDefaultDownloadPath = useSettingsStore((s) => s.setDefaultDownloadPath);
-  const { setShowNewDownloadDialog, setShowBatchImportDialog, showBulkDeleteDialog, setShowBulkDeleteDialog } = useUIStore();
+  const { showBulkDeleteDialog, setShowBulkDeleteDialog } = useUIStore();
   const { selectedIds, downloads, removeDownload, clearSelection } = useDownloadStore();
   const [actualTheme, setActualTheme] = useState<"light" | "dark">("light");
   const { t } = useTranslation();
@@ -184,9 +184,8 @@ function AppContent() {
     if (isTauri()) {
       import('@tauri-apps/api/event').then(({ listen }) => {
         listen<string>('set-download-url', (event) => {
-          // Store URL and open dialog
-          setPendingClipboardUrls([event.payload]);
-          setShowNewDownloadDialog(true);
+          // Route through the shared intake so it opens (or re-fills) the dialog.
+          ingestPastedUrls([event.payload]);
         }).then((unlistenFn) => {
           unlisten = unlistenFn;
         }).catch(console.error);
@@ -197,7 +196,7 @@ function AppContent() {
       cleanup();
       if (unlisten) unlisten();
     };
-  }, [setShowNewDownloadDialog]);
+  }, []);
 
   // Handle paste for links
   useEffect(() => {
@@ -208,46 +207,28 @@ function AppContent() {
         return;
       }
       
-      const text = e.clipboardData?.getData("text");
-      if (!text) return;
-      
-      const urls = parseUrls(text);
+      // Extract from the full clipboard payload (uri-list + plain text + HTML
+      // anchor hrefs) — not just plain text. This is the reliable way to import
+      // a multi-link selection (e.g. a GitHub release list, where the links live
+      // in anchor hrefs): the clipboard keeps absolutized HTML even when a drag
+      // would only carry plain text.
+      const urls = extractUrlsFromDataTransfer(e.clipboardData);
       if (urls.length === 0) return;
-      
-      // Prevent default paste behavior
+
+      // Prevent default paste behavior, then route through the shared intake.
       e.preventDefault();
-      
-      // Store URLs for dialogs to use
-      setPendingClipboardUrls(urls);
-      
-      if (urls.length === 1) {
-        // Single URL - open new download dialog
-        setShowNewDownloadDialog(true);
-      } else {
-        // Multiple URLs - open batch import dialog
-        setShowBatchImportDialog(true);
-      }
+      ingestPastedUrls(urls);
     };
 
     window.addEventListener("paste", handlePaste);
     return () => window.removeEventListener("paste", handlePaste);
-  }, [setShowNewDownloadDialog, setShowBatchImportDialog]);
+  }, []);
 
-  // Handle dropped URLs from DropZoneOverlay
+  // Handle dropped URLs from DropZoneOverlay (routing + empty-drop feedback live
+  // in the shared intake pipeline).
   const handleDrop = useCallback((urls: string[]) => {
-    if (urls.length === 0) return;
-
-    // Store URLs in the drop store (separate from clipboard)
-    setPendingDropUrls(urls);
-
-    if (urls.length === 1) {
-      // Single URL - open new download dialog
-      setShowNewDownloadDialog(true);
-    } else if (urls.length > 1) {
-      // Multiple URLs - open batch import dialog
-      setShowBatchImportDialog(true);
-    }
-  }, [setShowNewDownloadDialog, setShowBatchImportDialog]);
+    ingestDroppedUrls(urls);
+  }, []);
 
   return (
     <div>

--- a/apps/desktop/src/components/DropZoneOverlay.tsx
+++ b/apps/desktop/src/components/DropZoneOverlay.tsx
@@ -1,21 +1,12 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Download, Link } from 'lucide-react';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { useTranslation } from 'react-i18next';
 import { useUIStore } from '@/stores/ui';
-import { parseUrls } from '@/lib/utils';
-
-// Check if we're in Tauri context
-const isTauri = () => typeof window !== 'undefined' && (window as any).__TAURI_INTERNALS__ !== undefined;
+import { extractUrlsFromDataTransfer } from '@/lib/url-intake';
 
 interface DropZoneOverlayProps {
   onDrop: (urls: string[]) => void;
-}
-
-interface TauriFileDrop {
-  paths: string[];
-  position: { x: number; y: number };
 }
 
 export function DropZoneOverlay({ onDrop }: DropZoneOverlayProps) {
@@ -40,30 +31,36 @@ export function DropZoneOverlay({ onDrop }: DropZoneOverlayProps) {
     return () => window.removeEventListener('keydown', handleKeyDown, true);
   }, [resetOverlay]);
 
-  // Handle web drag events on the window to show the overlay
+  // Window-level HTML5 drag/drop. With `dragDropEnabled: false` in the Tauri
+  // window config the webview receives native HTML5 DnD events (no `tauri://*`
+  // file-drop interception), so this is the single source of truth for drops.
   useEffect(() => {
+    const hasDraggableUrls = (e: DragEvent) => {
+      const types = e.dataTransfer?.types;
+      if (!types) return false;
+      return (
+        types.includes('Files') ||
+        types.includes('text/uri-list') ||
+        types.includes('text/plain') ||
+        types.includes('text/html')
+      );
+    };
+
     const handleDragEnter = (e: DragEvent) => {
       if (isInternalDrag) return;
-      
-      // Check if it's a file or a link
-      const isFile = e.dataTransfer?.types.includes('Files');
-      const isLink = e.dataTransfer?.types.includes('text/uri-list');
-      const isPlain = e.dataTransfer?.types.includes('text/plain');
-      
-      if (isFile || isLink || isPlain) {
-        e.preventDefault();
-        e.stopPropagation();
-        dragCounter.current++;
-        if (dragCounter.current === 1) {
-          setIsExternalDrag(true);
-        }
+      if (!hasDraggableUrls(e)) return;
+      e.preventDefault();
+      dragCounter.current++;
+      if (dragCounter.current === 1) {
+        setIsExternalDrag(true);
       }
     };
 
     const handleDragOver = (e: DragEvent) => {
       if (isInternalDrag) return;
+      if (!hasDraggableUrls(e)) return;
+      // Required so the subsequent `drop` event fires at all.
       e.preventDefault();
-      e.stopPropagation();
       if (dragCounter.current === 0) {
         dragCounter.current = 1;
         setIsExternalDrag(true);
@@ -73,7 +70,6 @@ export function DropZoneOverlay({ onDrop }: DropZoneOverlayProps) {
     const handleDragLeave = (e: DragEvent) => {
       if (isInternalDrag) return;
       e.preventDefault();
-      e.stopPropagation();
       dragCounter.current--;
       if (dragCounter.current <= 0) {
         resetOverlay();
@@ -82,54 +78,31 @@ export function DropZoneOverlay({ onDrop }: DropZoneOverlayProps) {
 
     const handleDrop = (e: DragEvent) => {
       if (isInternalDrag) return;
+      // preventDefault cancels the native drop action (e.g. inserting the URL
+      // into a focused <input> when a dialog is open), so the link is handled
+      // by our pipeline instead of being swallowed by the field.
       e.preventDefault();
-      e.stopPropagation();
       resetOverlay();
 
-      const urls: string[] = [];
+      const urls = extractUrlsFromDataTransfer(e.dataTransfer);
 
-      // 1) text/uri-list (often provided by browsers for link drags)
-      const uriList = e.dataTransfer?.getData('text/uri-list');
-      if (uriList) {
-        const lines = uriList
-          .split('\n')
-          .map((l) => l.trim())
-          .filter((line) => line && !line.startsWith('#'));
-        urls.push(...lines.filter((u) => u.startsWith('http://') || u.startsWith('https://')));
+      // Diagnostic: if a drop carried data but yielded no links, log exactly what
+      // the webview delivered. Cross-app drags into the WebKit/WebView can
+      // withhold text/html, leaving only plain text without URLs — this makes
+      // that visible in DevTools instead of a mysterious "No URLs found".
+      if (urls.length === 0 && e.dataTransfer) {
+        const dt = e.dataTransfer;
+        console.warn('[DLMan] drop produced no URLs', {
+          types: Array.from(dt.types || []),
+          'text/plain': dt.getData('text/plain')?.slice(0, 400),
+          'text/uri-list': dt.getData('text/uri-list')?.slice(0, 400),
+          'text/html': dt.getData('text/html')?.slice(0, 800),
+        });
       }
 
-      // 2) text/plain (can contain multiple URLs when user drags selected text)
-      const text = e.dataTransfer?.getData('text/plain');
-      if (text) {
-        urls.push(...parseUrls(text));
-      }
-
-      // 3) text/html (common when dragging selected anchors from a page)
-      // Only parse if we don't already have URLs from uri-list or text/plain
-      const html = e.dataTransfer?.getData('text/html');
-      if (html && urls.length === 0) {
-        try {
-          const doc = new DOMParser().parseFromString(html, 'text/html');
-          const hrefs = Array.from(doc.querySelectorAll('a'))
-            .map((a) => a.getAttribute('href'))
-            .filter((href): href is string => !!href)
-            .filter((href) => href.startsWith('http://') || href.startsWith('https://'))
-            // Filter out XML namespace URLs and other non-downloadable URLs
-            .filter((href) => !href.includes('w3.org/') && !href.includes('xmlns'));
-          urls.push(...hrefs);
-        } catch {
-          // ignore
-        }
-      }
-
-      // De-dupe while preserving order and filter out any remaining non-download URLs
-      const filteredUrls = Array.from(new Set(urls)).filter(
-        (url) => !url.includes('w3.org/') && !url.includes('xmlns') && !url.includes('schema.org')
-      );
-
-      if (filteredUrls.length > 0) {
-        onDrop(filteredUrls);
-      }
+      // Always call onDrop — it gives feedback even when nothing matched, so a
+      // drop never silently does nothing.
+      onDrop(urls);
     };
 
     window.addEventListener('dragenter', handleDragEnter);
@@ -143,56 +116,7 @@ export function DropZoneOverlay({ onDrop }: DropZoneOverlayProps) {
       window.removeEventListener('dragleave', handleDragLeave);
       window.removeEventListener('drop', handleDrop);
     };
-  }, [isInternalDrag, resetOverlay]);
-
-  // Listen to Tauri drag/drop events for external files
-  useEffect(() => {
-    if (!isTauri()) return;
-
-    let unlistenHover: UnlistenFn | undefined;
-    let unlistenDrop: UnlistenFn | undefined;
-    let unlistenCancel: UnlistenFn | undefined;
-
-    const setupTauriListeners = async () => {
-      try {
-        unlistenHover = await listen('tauri://drag-over', () => {
-          if (!isInternalDrag) {
-            setIsExternalDrag(true);
-          }
-        });
-
-        unlistenCancel = await listen('tauri://drag-leave', resetOverlay);
-
-        unlistenDrop = await listen<TauriFileDrop>('tauri://drop', (event) => {
-          if (!isInternalDrag) {
-            const paths = event.payload.paths || [];
-            const urls: string[] = [];
-            
-            paths.forEach((path: string) => {
-              if (path.match(/^https?:\/\//)) {
-                urls.push(path);
-              }
-            });
-            
-            if (urls.length > 0) {
-              onDrop(urls);
-            }
-          }
-          resetOverlay();
-        });
-      } catch (err) {
-        console.error('Failed to set up Tauri drag-drop listeners:', err);
-      }
-    };
-
-    setupTauriListeners();
-
-    return () => {
-      unlistenHover?.();
-      unlistenDrop?.();
-      unlistenCancel?.();
-    };
-  }, [onDrop, resetOverlay, isInternalDrag]);
+  }, [isInternalDrag, resetOverlay, onDrop]);
 
   const shouldShow = isExternalDrag && !isInternalDrag;
 

--- a/apps/desktop/src/components/dialogs/BatchImportDialog.tsx
+++ b/apps/desktop/src/components/dialogs/BatchImportDialog.tsx
@@ -100,6 +100,8 @@ function isHtmlItem(item: Item): boolean {
 export function BatchImportDialog() {
   const { t } = useTranslation();
   const { showBatchImportDialog, setShowBatchImportDialog } = useUIStore();
+  // Re-run intake when new links are routed in while the dialog is already open.
+  const urlIntakeNonce = useUIStore((s) => s.urlIntakeNonce);
   const addDownload = useDownloadStore((s) => s.addDownload);
   const setFilter = useDownloadStore((s) => s.setFilter);
 
@@ -244,18 +246,19 @@ export function BatchImportDialog() {
     });
   }, []); // Stable - runProbe is also stable
 
-  // Open behavior: ONLY runs when dialog opens (showBatchImportDialog changes to true)
-  const hasInitializedRef = useRef(false);
+  // Open behavior: runs when the dialog opens AND when a fresh set of links is
+  // routed in while it's already open (keyed on the intake nonce).
+  const processedIntakeRef = useRef<string>('');
   useEffect(() => {
     if (!showBatchImportDialog) {
-      // Dialog closed - reset for next open
-      hasInitializedRef.current = false;
+      // Dialog closed - arm the next open to re-initialize.
+      processedIntakeRef.current = '';
       return;
     }
 
-    // Only initialize once per open
-    if (hasInitializedRef.current) return;
-    hasInitializedRef.current = true;
+    const intakeKey = String(urlIntakeNonce);
+    if (processedIntakeRef.current === intakeKey) return;
+    processedIntakeRef.current = intakeKey;
 
     const clipboardUrls = getPendingClipboardUrls();
     const dropUrls = getPendingDropUrls();
@@ -282,7 +285,7 @@ export function BatchImportDialog() {
     setFocusedIndex(null);
     anchorIndexRef.current = null;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showBatchImportDialog]); // Only depend on showBatchImportDialog - other functions are stable
+  }, [showBatchImportDialog, urlIntakeNonce]); // other functions are stable
 
   // Hide HTML: UI-only filter. No probing.
   useEffect(() => {

--- a/apps/desktop/src/components/dialogs/NewDownloadDialog.tsx
+++ b/apps/desktop/src/components/dialogs/NewDownloadDialog.tsx
@@ -55,6 +55,10 @@ const isTauri = () => typeof window !== 'undefined' && (window as any).__TAURI_I
 export function NewDownloadDialog() {
   const { t } = useTranslation();
   const { showNewDownloadDialog, setShowNewDownloadDialog } = useUIStore();
+  // Bumped whenever URLs are routed here (drop/paste/extension). We re-consume
+  // on every change so a link dropped while the dialog is already open still
+  // populates the field instead of being ignored.
+  const urlIntakeNonce = useUIStore((s) => s.urlIntakeNonce);
   const queues = useQueuesArray();
   const selectedQueueId = useQueueStore((s) => s.selectedQueueId);
   const setSelectedQueue = useQueueStore((s) => s.setSelectedQueue);
@@ -102,23 +106,24 @@ export function NewDownloadDialog() {
     referrer?: string;
   } | undefined>(undefined);
 
-  // Guard against React StrictMode double-firing effects.
-  // getPendingMediaMeta/Cookies/ClipboardUrls are consume-once functions that
-  // return undefined on the second call. Without this guard, StrictMode's
-  // second effect invocation clears all the pending values.
-  const pendingConsumedRef = useRef(false);
+  // Tracks which intake we've already processed. Keyed on the intake nonce so
+  // the effect runs once per open AND once per new drop/paste while open, but
+  // not on unrelated re-renders (which would clobber consume-once pending reads
+  // under React StrictMode).
+  const processedIntakeRef = useRef<string>('');
 
-  // Reset state and check for pending URLs when dialog opens
+  // Reset state and check for pending URLs when the dialog opens or a new URL
+  // is routed in while it's already open.
   useEffect(() => {
     if (!showNewDownloadDialog) {
-      // Dialog closing — reset the consumption guard for next open
-      pendingConsumedRef.current = false;
+      // Dialog closing — arm the next open to re-process.
+      processedIntakeRef.current = '';
       return;
     }
 
-    // StrictMode guard: skip consume-once reads on the second invocation
-    if (pendingConsumedRef.current) return;
-    pendingConsumedRef.current = true;
+    const intakeKey = String(urlIntakeNonce);
+    if (processedIntakeRef.current === intakeKey) return;
+    processedIntakeRef.current = intakeKey;
 
     // Check for pending clipboard/drop URLs
     const clipboardUrls = getPendingClipboardUrls();
@@ -157,7 +162,7 @@ export function NewDownloadDialog() {
     
     // Set default path
     initializeDefaultPath();
-  }, [showNewDownloadDialog, selectedQueueId]);
+  }, [showNewDownloadDialog, selectedQueueId, urlIntakeNonce]);
 
   const initializeDefaultPath = async () => {
     const basePath = await getDefaultBasePath();
@@ -449,23 +454,25 @@ export function NewDownloadDialog() {
 
   return (
     <Dialog open={showNewDownloadDialog} onOpenChange={setShowNewDownloadDialog}>
-      <DialogContent className="sm:max-w-[500px] max-h-[85vh] overflow-hidden flex flex-col">
-        <DialogHeader className="shrink-0">
-          <DialogTitle className="flex items-center gap-2">
+      <DialogContent className="sm:max-w-[540px] max-h-[88vh] overflow-hidden flex flex-col gap-0 p-0">
+        <DialogHeader className="shrink-0 flex-row items-center gap-3 space-y-0 border-b px-6 py-4">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary ring-1 ring-inset ring-primary/20">
             <Download className="h-5 w-5" />
-            {t('menu.newDownload')}
-          </DialogTitle>
-          <DialogDescription>
-            {t('newDownload.desc')}
-          </DialogDescription>
+          </div>
+          <div className="min-w-0 flex-1 text-left">
+            <DialogTitle className="text-base">{t('menu.newDownload')}</DialogTitle>
+            <DialogDescription className="mt-0.5 text-xs">
+              {t('newDownload.desc')}
+            </DialogDescription>
+          </div>
         </DialogHeader>
 
-        <div className="flex-1 min-h-0 overflow-y-auto px-1 -mx-1">
-          <div className="space-y-4 py-4 px-0.5">
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <div className="space-y-5 px-6 py-5">
           {/* URL Input */}
           <div className="space-y-2">
-            <Label htmlFor="url" className="flex items-center gap-2">
-              <Link className="h-4 w-4" />
+            <Label htmlFor="url" className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+              <Link className="h-3.5 w-3.5" />
               {t('newDownload.url')}
             </Label>
             <div className="flex gap-2">
@@ -475,7 +482,7 @@ export function NewDownloadDialog() {
                   value={url}
                   onChange={(e) => setUrl(e.target.value)}
                   placeholder={t('newDownload.urlPlaceholder')}
-                  className="pr-10"
+                  className="h-11 pr-10"
                 />
                 <AnimatePresence>
                   {isProbing && (
@@ -523,6 +530,7 @@ export function NewDownloadDialog() {
               <Button
                 variant="outline"
                 size="icon"
+                className="h-11 w-11 shrink-0"
                 onClick={handlePasteFromClipboard}
                 title={t('newDownload.pasteClipboard')}
               >
@@ -576,22 +584,26 @@ export function NewDownloadDialog() {
                 initial={{ opacity: 0, height: 0 }}
                 animate={{ opacity: 1, height: 'auto' }}
                 exit={{ opacity: 0, height: 0 }}
-                className="rounded-md border border-border bg-muted/50 p-3 space-y-3"
+                className="rounded-xl border bg-muted/40 p-3 space-y-3"
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2 flex-1 min-w-0">
-                    <FileText className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                    <span className="text-sm font-medium truncate">{effectiveFilename}</span>
-                    {filenameEdited && (
-                      <span className="text-xs text-primary bg-primary/10 px-1.5 py-0.5 rounded">{t('newDownload.customBadge')}</span>
-                    )}
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2.5 flex-1 min-w-0">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-background text-muted-foreground ring-1 ring-inset ring-border">
+                      <FileText className="h-4 w-4" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-sm font-medium truncate">{effectiveFilename}</span>
+                        {filenameEdited && (
+                          <span className="shrink-0 text-[10px] text-primary bg-primary/10 px-1.5 py-0.5 rounded">{t('newDownload.customBadge')}</span>
+                        )}
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {fileSize ? formatFileSize(fileSize) : (isProbing ? t('newDownload.adding') : '—')}
+                      </span>
+                    </div>
                   </div>
                   <div className="flex items-center gap-2 flex-shrink-0">
-                    {fileSize && (
-                      <span className="text-sm text-muted-foreground">
-                        {formatFileSize(fileSize)}
-                      </span>
-                    )}
                     <Button
                       variant="ghost"
                       size="sm"
@@ -657,8 +669,8 @@ export function NewDownloadDialog() {
 
           {/* Destination */}
           <div className="space-y-2">
-            <Label htmlFor="destination" className="flex items-center gap-2">
-              <Folder className="h-4 w-4" />
+            <Label htmlFor="destination" className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+              <Folder className="h-3.5 w-3.5" />
               {t('newDownload.saveTo')}
             </Label>
             <div className="flex gap-2">
@@ -701,11 +713,11 @@ export function NewDownloadDialog() {
 
           {/* Category Selection */}
           <div className="space-y-2">
-            <Label htmlFor="category" className="flex items-center gap-2">
-              <Tag className="h-4 w-4" />
+            <Label htmlFor="category" className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+              <Tag className="h-3.5 w-3.5" />
               {t('newDownload.category')}
               {categoryId && (
-                <span className="text-xs text-muted-foreground">{t('newDownload.autoDetected')}</span>
+                <span className="text-[10px] font-normal text-primary">{t('newDownload.autoDetected')}</span>
               )}
             </Label>
             <Select value={categoryId || 'none'} onValueChange={handleCategoryChange}>
@@ -735,7 +747,7 @@ export function NewDownloadDialog() {
 
           {/* Queue Selection */}
           <div className="space-y-2">
-            <Label htmlFor="queue">{t('newDownload.queue')}</Label>
+            <Label htmlFor="queue" className="text-xs font-medium text-muted-foreground">{t('newDownload.queue')}</Label>
             <Select value={queueId} onValueChange={setQueueId}>
               <SelectTrigger>
                 <SelectValue placeholder={t('newDownload.selectQueue')} />
@@ -758,15 +770,18 @@ export function NewDownloadDialog() {
           </div>
         </div>
 
-        <DialogFooter className="shrink-0 gap-2 sm:gap-0">
+        {/* Footer. Start / Download Later only require a URL + destination — they
+            are intentionally NOT gated on the probe, so a download can be started
+            immediately even while the file size is still being detected. */}
+        <DialogFooter className="shrink-0 flex-row items-center justify-end gap-2 border-t px-6 py-4">
           <Button
-            variant="outline"
+            variant="ghost"
             onClick={() => setShowNewDownloadDialog(false)}
           >
             {t('common.cancel')}
           </Button>
           <Button
-            variant="secondary"
+            variant="outline"
             onClick={() => handleAddDownload(true)}
             disabled={!url || !destination || isAdding}
             title={t('newDownload.downloadLaterTitle')}

--- a/apps/desktop/src/components/downloads/DownloadList.tsx
+++ b/apps/desktop/src/components/downloads/DownloadList.tsx
@@ -16,17 +16,47 @@ interface DownloadListProps {
   downloads: Download[];
 }
 
+// Marquee tuning
+const MARQUEE_THRESHOLD = 4; // px of movement before a press becomes a drag-select
+const AUTO_SCROLL_EDGE = 56; // px from top/bottom edge where auto-scroll kicks in
+const AUTO_SCROLL_MAX = 18; // max px/frame auto-scroll speed
+
+interface MarqueeRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface MarqueeDragState {
+  baseSelection: Set<string>; // selection to merge into (existing when shift-drag, else empty)
+  startX: number; // content-space coords (include scroll offset)
+  startY: number;
+  pointerId: number;
+  additive: boolean;
+  moved: boolean;
+  lastClientX: number;
+  lastClientY: number;
+}
+
 export function DownloadList({ downloads }: DownloadListProps) {
   const { t } = useTranslation();
   const parentRef = useRef<HTMLDivElement>(null);
   const focusedId = useDownloadStore((s) => s.focusedId);
   const setFocusedId = useDownloadStore((s) => s.setFocusedId);
   const toggleSelected = useDownloadStore((s) => s.toggleSelected);
+  const setSelected = useDownloadStore((s) => s.setSelected);
+  const clearSelection = useDownloadStore((s) => s.clearSelection);
   const removeDownload = useDownloadStore((s) => s.removeDownload);
 
   // Delete confirmation dialog state
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [downloadToDelete, setDownloadToDelete] = useState<Download | null>(null);
+
+  // Marquee (rubber-band) selection
+  const [marqueeRect, setMarqueeRect] = useState<MarqueeRect | null>(null);
+  const marqueeRef = useRef<MarqueeDragState | null>(null);
+  const autoScrollRafRef = useRef<number | null>(null);
 
   const virtualizer = useVirtualizer({
     count: downloads.length,
@@ -49,6 +79,199 @@ export function DownloadList({ downloads }: DownloadListProps) {
     }
   }, [focusedIndex, virtualizer]);
 
+  // ----- Marquee selection -----------------------------------------------
+  // Translate a viewport point into content-space coords (so selection stays
+  // correct across scrolling / auto-scroll).
+  const getContentPoint = useCallback((clientX: number, clientY: number) => {
+    const el = parentRef.current;
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return {
+      x: clientX - rect.left + el.scrollLeft,
+      y: clientY - rect.top + el.scrollTop,
+    };
+  }, []);
+
+  // Select every item whose row overlaps the vertical band, merged onto `base`.
+  const applyMarqueeSelection = useCallback(
+    (startY: number, endY: number, base: Set<string>) => {
+      const total = virtualizer.getTotalSize();
+      const rawMin = Math.min(startY, endY);
+      const rawMax = Math.max(startY, endY);
+      const selected = new Set(base);
+
+      // Only intersect when the band actually overlaps the content range.
+      if (downloads.length > 0 && rawMax >= 0 && rawMin <= total - 1) {
+        const min = Math.max(0, rawMin);
+        const max = Math.min(total - 1, rawMax);
+        const first = virtualizer.getVirtualItemForOffset(min);
+        const last = virtualizer.getVirtualItemForOffset(max);
+        if (first && last) {
+          const lo = Math.min(first.index, last.index);
+          const hi = Math.max(first.index, last.index);
+          for (let i = lo; i <= hi; i++) {
+            const d = downloads[i];
+            if (d) selected.add(d.id);
+          }
+        }
+      }
+
+      setSelected(Array.from(selected));
+    },
+    [virtualizer, downloads, setSelected]
+  );
+
+  const updateMarqueeFromClient = useCallback(
+    (clientX: number, clientY: number) => {
+      const state = marqueeRef.current;
+      if (!state) return;
+      state.lastClientX = clientX;
+      state.lastClientY = clientY;
+
+      const p = getContentPoint(clientX, clientY);
+      if (!p) return;
+
+      if (!state.moved) {
+        if (
+          Math.abs(p.x - state.startX) < MARQUEE_THRESHOLD &&
+          Math.abs(p.y - state.startY) < MARQUEE_THRESHOLD
+        ) {
+          return; // not a drag yet
+        }
+        state.moved = true;
+      }
+
+      setMarqueeRect({
+        left: Math.min(state.startX, p.x),
+        top: Math.min(state.startY, p.y),
+        width: Math.abs(p.x - state.startX),
+        height: Math.abs(p.y - state.startY),
+      });
+      applyMarqueeSelection(state.startY, p.y, state.baseSelection);
+    },
+    [getContentPoint, applyMarqueeSelection]
+  );
+
+  const stopAutoScroll = useCallback(() => {
+    if (autoScrollRafRef.current != null) {
+      cancelAnimationFrame(autoScrollRafRef.current);
+      autoScrollRafRef.current = null;
+    }
+  }, []);
+
+  const ensureAutoScroll = useCallback(() => {
+    if (autoScrollRafRef.current != null) return;
+    const tick = () => {
+      const el = parentRef.current;
+      const state = marqueeRef.current;
+      if (!el || !state) {
+        autoScrollRafRef.current = null;
+        return;
+      }
+      const rect = el.getBoundingClientRect();
+      const y = state.lastClientY;
+      let delta = 0;
+      if (y < rect.top + AUTO_SCROLL_EDGE) {
+        delta = -Math.ceil(((rect.top + AUTO_SCROLL_EDGE - y) / AUTO_SCROLL_EDGE) * AUTO_SCROLL_MAX);
+      } else if (y > rect.bottom - AUTO_SCROLL_EDGE) {
+        delta = Math.ceil(((y - (rect.bottom - AUTO_SCROLL_EDGE)) / AUTO_SCROLL_EDGE) * AUTO_SCROLL_MAX);
+      }
+      if (delta !== 0) {
+        const maxScroll = el.scrollHeight - el.clientHeight;
+        const before = el.scrollTop;
+        el.scrollTop = Math.max(0, Math.min(maxScroll, el.scrollTop + delta));
+        if (el.scrollTop !== before) {
+          updateMarqueeFromClient(state.lastClientX, state.lastClientY);
+        }
+      }
+      autoScrollRafRef.current = requestAnimationFrame(tick);
+    };
+    autoScrollRafRef.current = requestAnimationFrame(tick);
+  }, [updateMarqueeFromClient]);
+
+  const endMarquee = useCallback(() => {
+    const state = marqueeRef.current;
+    marqueeRef.current = null;
+    stopAutoScroll();
+    setMarqueeRect(null);
+    if (state) {
+      try {
+        parentRef.current?.releasePointerCapture(state.pointerId);
+      } catch {
+        // capture may already be gone
+      }
+    }
+    return state;
+  }, [stopAutoScroll]);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      // Primary button only.
+      if (e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      // Presses on an item (drag-to-queue / click) or any interactive control
+      // are not marquee starts — only empty list space is.
+      if (target.closest('[data-download-item]')) return;
+      if (
+        target.closest(
+          'button, a, input, textarea, [role="checkbox"], [role="menuitem"], [data-radix-popper-content-wrapper]'
+        )
+      ) {
+        return;
+      }
+
+      const p = getContentPoint(e.clientX, e.clientY);
+      if (!p) return;
+
+      const additive = e.shiftKey;
+      marqueeRef.current = {
+        baseSelection: additive
+          ? new Set(useDownloadStore.getState().selectedIds)
+          : new Set<string>(),
+        startX: p.x,
+        startY: p.y,
+        pointerId: e.pointerId,
+        additive,
+        moved: false,
+        lastClientX: e.clientX,
+        lastClientY: e.clientY,
+      };
+      try {
+        parentRef.current?.setPointerCapture(e.pointerId);
+      } catch {
+        // ignore
+      }
+      ensureAutoScroll();
+    },
+    [getContentPoint, ensureAutoScroll]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!marqueeRef.current) return;
+      updateMarqueeFromClient(e.clientX, e.clientY);
+      if (marqueeRef.current?.moved) e.preventDefault();
+    },
+    [updateMarqueeFromClient]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    const state = endMarquee();
+    if (!state) return;
+    // A plain click on empty space (no drag) clears the selection — unless the
+    // user was holding shift to keep/extend it.
+    if (!state.moved && !state.additive) {
+      clearSelection();
+    }
+  }, [endMarquee, clearSelection]);
+
+  const handlePointerCancel = useCallback(() => {
+    endMarquee();
+  }, [endMarquee]);
+
+  // Clean up any running auto-scroll on unmount.
+  useEffect(() => stopAutoScroll, [stopAutoScroll]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (downloads.length === 0) return;
@@ -59,12 +282,25 @@ export function DownloadList({ downloads }: DownloadListProps) {
         return;
       }
 
+      // Ctrl/Cmd+A selects everything in the current view.
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "a") {
+        e.preventDefault();
+        setSelected(downloads.map((d) => d.id));
+        return;
+      }
+
+      if (e.key === "Escape") {
+        e.preventDefault();
+        clearSelection();
+        return;
+      }
+
       if (e.key === "ArrowDown") {
         e.preventDefault();
         const currentIndex = focusedIndex >= 0 ? focusedIndex : -1;
         const nextIndex = Math.min(currentIndex + 1, downloads.length - 1);
         setFocusedId(downloads[nextIndex].id);
-        
+
         // If shift is held, also select the item
         if (e.shiftKey && downloads[nextIndex]) {
           toggleSelected(downloads[nextIndex].id, true);
@@ -74,7 +310,7 @@ export function DownloadList({ downloads }: DownloadListProps) {
         const currentIndex = focusedIndex >= 0 ? focusedIndex : downloads.length;
         const prevIndex = Math.max(currentIndex - 1, 0);
         setFocusedId(downloads[prevIndex].id);
-        
+
         // If shift is held, also select the item
         if (e.shiftKey && downloads[prevIndex]) {
           toggleSelected(downloads[prevIndex].id, true);
@@ -111,18 +347,18 @@ export function DownloadList({ downloads }: DownloadListProps) {
         }
       }
     },
-    [downloads, focusedId, focusedIndex, setFocusedId, toggleSelected]
+    [downloads, focusedId, focusedIndex, setFocusedId, toggleSelected, setSelected, clearSelection]
   );
 
   // Handle delete confirmation
   const handleConfirmDelete = useCallback(async (deleteFile: boolean) => {
     if (!downloadToDelete) return;
-    
+
     setShowDeleteDialog(false);
-    
+
     // Remove from store first
     removeDownload(downloadToDelete.id);
-    
+
     if (isTauri()) {
       try {
         // If user chose to also delete the file, use delete_file: true
@@ -147,9 +383,13 @@ export function DownloadList({ downloads }: DownloadListProps) {
     <>
       <div
         ref={parentRef}
-        className="h-full overflow-auto focus:outline-none p-2"
+        className="h-full overflow-auto focus:outline-none p-2 select-none"
         tabIndex={0}
         onKeyDown={handleKeyDown}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
       >
         <div
           className="relative w-full min-w-0"
@@ -174,9 +414,22 @@ export function DownloadList({ downloads }: DownloadListProps) {
               </div>
             );
           })}
+
+          {/* Rubber-band selection rectangle (content-space coords) */}
+          {marqueeRect && (
+            <div
+              className="pointer-events-none absolute z-20 rounded-sm border border-primary bg-primary/10"
+              style={{
+                left: `${marqueeRect.left}px`,
+                top: `${marqueeRect.top}px`,
+                width: `${marqueeRect.width}px`,
+                height: `${marqueeRect.height}px`,
+              }}
+            />
+          )}
         </div>
       </div>
-      
+
       {/* Delete Confirmation Dialog */}
       {downloadToDelete && (
         <DeleteConfirmDialog

--- a/apps/desktop/src/lib/events.ts
+++ b/apps/desktop/src/lib/events.ts
@@ -301,28 +301,10 @@ export function setupEventListeners(): () => void {
     }
   }));
 
-  // Listen for Tauri file drop events (tauri://drop)
-  registerListener(listen<{ paths: string[]; position: { x: number; y: number } }>(
-    "tauri://drop",
-    (event) => {
-      if (isCleanedUp) return;
-      const { paths } = event.payload;
-      
-      // Filter for URLs (files starting with http)
-      // Note: Tauri drops files as paths, but we can also handle dropped text/URLs
-      // For now, just check if any path looks like a URL
-      const urls = paths.filter(p => p.startsWith('http://') || p.startsWith('https://'));
-      
-      if (urls.length > 0) {
-        setPendingDropUrls(urls);
-        if (urls.length === 1) {
-          useUIStore.getState().setShowNewDownloadDialog(true);
-        } else {
-          useUIStore.getState().setShowBatchImportDialog(true);
-        }
-      }
-    }
-  ));
+  // Note: there is intentionally no `tauri://drop` listener. The window is
+  // configured with `dragDropEnabled: false`, so the webview handles drops via
+  // native HTML5 DnD (see DropZoneOverlay + lib/url-intake). A Tauri file-drop
+  // listener here would never fire and only invite confusion.
 
   // Listen for show-new-download-dialog event (from deep links / extension)
   // Payload can be a plain URL string (legacy) or structured object with url, referrer, filename, cookies
@@ -359,8 +341,8 @@ export function setupEventListeners(): () => void {
         }
       }
       
-      // Show the new download dialog
-      useUIStore.getState().setShowNewDownloadDialog(true);
+      // Open (or re-fill, if already open) the new download dialog.
+      useUIStore.getState().routeUrlIntake(1);
     }
   ));
 
@@ -373,7 +355,7 @@ export function setupEventListeners(): () => void {
       
       if (urls && urls.length > 0) {
         setPendingDropUrls(urls);
-        useUIStore.getState().setShowBatchImportDialog(true);
+        useUIStore.getState().routeUrlIntake(urls.length);
       }
     }
   ));

--- a/apps/desktop/src/lib/url-intake.ts
+++ b/apps/desktop/src/lib/url-intake.ts
@@ -1,0 +1,123 @@
+// Central pipeline for URLs arriving from drops, pastes, or the browser
+// extension. One place decides how links are extracted, cleaned, and routed to
+// the right dialog — so behavior is identical no matter where the links came
+// from (a dragged anchor, a dragged text selection, a paste, etc.).
+
+import { toast } from 'sonner';
+import i18n from '@/i18n';
+import { useUIStore } from '@/stores/ui';
+import { setPendingClipboardUrls, setPendingDropUrls } from '@/lib/events';
+import { parseUrls } from '@/lib/utils';
+
+// Substrings that show up in dragged HTML/text but are never downloadable
+// (XML namespaces, schema declarations, etc.).
+const JUNK_MARKERS = ['w3.org/', 'xmlns', 'schema.org'];
+
+function isHttpUrl(value: string): boolean {
+  return value.startsWith('http://') || value.startsWith('https://');
+}
+
+/** De-dupe while preserving order and drop non-downloadable/junk URLs. */
+export function cleanUrls(urls: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of urls) {
+    const url = raw.trim();
+    if (!url || !isHttpUrl(url)) continue;
+    if (JUNK_MARKERS.some((marker) => url.includes(marker))) continue;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    out.push(url);
+  }
+  return out;
+}
+
+/**
+ * Extract every downloadable URL from a drag's DataTransfer.
+ *
+ * We merge ALL sources (uri-list + plain text + HTML anchors) instead of
+ * stopping at the first that yields something. That's the key fix for the
+ * "sometimes the dialog opens, sometimes it doesn't" bug: a selection can put
+ * one incidental URL in text/plain while the real links live only in the anchor
+ * hrefs of text/html — short-circuiting on text/plain would miss them entirely.
+ */
+export function extractUrlsFromDataTransfer(dt: DataTransfer | null): string[] {
+  if (!dt) return [];
+  const urls: string[] = [];
+
+  // 1) text/uri-list — what browsers provide for a single dragged link.
+  const uriList = dt.getData('text/uri-list');
+  const uriListLines = uriList
+    ? uriList
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith('#'))
+    : [];
+  urls.push(...uriListLines);
+
+  // 2) text/plain — URLs that appear literally in dragged/selected text.
+  const text = dt.getData('text/plain');
+  if (text) {
+    urls.push(...parseUrls(text));
+  }
+
+  // 3) text/html — anchor hrefs from a dragged selection or link. Always parsed
+  //    and merged (not only as a fallback) so href-only links are never lost
+  //    (e.g. a GitHub release list where the visible text is just filenames).
+  const html = dt.getData('text/html');
+  if (html) {
+    try {
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const anchors = Array.from(doc.querySelectorAll('a[href]'))
+        .map((a) => a.getAttribute('href'))
+        .filter((href): href is string => !!href);
+
+      // Some sources (notably drags vs. copies) keep relative hrefs. Resolve
+      // them against a best-effort base: an explicit <base>, a uri-list URL, or
+      // the first absolute anchor in the fragment.
+      const base =
+        doc.querySelector('base[href]')?.getAttribute('href') ||
+        uriListLines.find(isHttpUrl) ||
+        anchors.find(isHttpUrl);
+
+      for (const href of anchors) {
+        if (isHttpUrl(href)) {
+          urls.push(href);
+        } else if (base) {
+          try {
+            urls.push(new URL(href, base).href);
+          } catch {
+            // unresolvable relative href — skip
+          }
+        }
+      }
+    } catch {
+      // Malformed HTML — ignore, the other sources still apply.
+    }
+  }
+
+  return cleanUrls(urls);
+}
+
+/**
+ * Route a set of dropped URLs into the right dialog. Always gives feedback —
+ * even an empty result toasts "no URLs found" rather than silently doing
+ * nothing (the previous behavior that made drops feel broken).
+ */
+export function ingestDroppedUrls(rawUrls: string[]): void {
+  const urls = cleanUrls(rawUrls);
+  if (urls.length === 0) {
+    toast.error(i18n.t('toasts.noUrlsFound'));
+    return;
+  }
+  setPendingDropUrls(urls);
+  useUIStore.getState().routeUrlIntake(urls.length);
+}
+
+/** Route URLs that came from a paste (clipboard channel). */
+export function ingestPastedUrls(rawUrls: string[]): void {
+  const urls = cleanUrls(rawUrls);
+  if (urls.length === 0) return; // pastes are noisy; stay silent when nothing matches
+  setPendingClipboardUrls(urls);
+  useUIStore.getState().routeUrlIntake(urls.length);
+}

--- a/apps/desktop/src/stores/ui.ts
+++ b/apps/desktop/src/stores/ui.ts
@@ -31,6 +31,10 @@ interface UIState {
   isDragging: boolean;
   dragOverTarget: string | null;
 
+  // URL intake (drop / paste / extension) — bumped every time URLs are routed
+  // to a dialog so the dialog re-consumes them even if it's already open.
+  urlIntakeNonce: number;
+
   // Dev console
   consoleHeight: number;
   consoleLogs: ConsoleLog[];
@@ -55,6 +59,11 @@ interface UIState {
 
   setIsDragging: (isDragging: boolean) => void;
   setDragOverTarget: (target: string | null) => void;
+
+  // Open the correct import dialog for `count` URLs (1 → New Download, >1 →
+  // Batch Import), closing the other, and bump the intake nonce so the target
+  // dialog re-reads the pending URLs even when it was already open.
+  routeUrlIntake: (count: number) => void;
 
   setConsoleHeight: (height: number) => void;
   setConsoleLogLimits: (limits: Partial<ConsoleLogLimits>) => void;
@@ -96,6 +105,7 @@ export const useUIStore = create<UIState>((set) => ({
   showBulkDeleteDialog: false,
   isDragging: false,
   dragOverTarget: null,
+  urlIntakeNonce: 0,
   consoleHeight: 200,
   consoleLogs: [],
   consoleLogLimits: { info: 200, warn: 100, error: 100, debug: 100 },
@@ -122,6 +132,13 @@ export const useUIStore = create<UIState>((set) => ({
 
   setIsDragging: (isDragging) => set({ isDragging }),
   setDragOverTarget: (dragOverTarget) => set({ dragOverTarget }),
+
+  routeUrlIntake: (count) =>
+    set((state) => ({
+      urlIntakeNonce: state.urlIntakeNonce + 1,
+      showNewDownloadDialog: count === 1,
+      showBatchImportDialog: count > 1,
+    })),
 
   setConsoleHeight: (consoleHeight) => set({ consoleHeight }),
   setConsoleLogLimits: (limits) =>

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dlman/extension",
   "displayName": "DLMan - Download Manager",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "description": "Browser extension for DLMan - Modern download manager integration",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dlman",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "A modern, open-source download manager",
   "keywords": ["download", "manager", "tauri", "rust", "react"],


### PR DESCRIPTION
## Summary

UX polish for the downloads list and link importing, plus a New Download dialog refresh. Released as **1.11.0**.

### Drag-to-select (marquee) in the downloads list
- Drag across empty list space to box-select multiple downloads — works in every view (All / queue / category).
- **Shift+drag** merges with the existing selection; plain drag replaces; click empty space clears.
- Edge auto-scroll for selecting beyond the viewport; **Ctrl/Cmd+A** select-all-in-view and **Esc** to clear.
- Implemented in content-space via the virtualizer's `getVirtualItemForOffset`, so it's correct across the whole virtualized list. Dragging on a row stays reserved for the existing drag-to-queue/category move.

### Reliable link importing (drop / paste / extension)
- One shared pipeline (`lib/url-intake`). Extraction merges all DataTransfer sources (uri-list + plain text + HTML anchor hrefs) and resolves relative hrefs, so href-only links (e.g. a GitHub release list) are no longer missed.
- **Paste** now reads the full clipboard (incl. HTML) — the reliable way to bulk-import a multi-link selection, since cross-app drags into WebKit can withhold `text/html`.
- A link dropped/pasted while a dialog is already open now **re-fills it** (`urlIntakeNonce`/`routeUrlIntake`) instead of being ignored. This also resolves "Start disabled until file loaded" — the field simply was never populated.
- Empty drops give feedback ("No URLs found") and log the delivered DataTransfer types for diagnosis. Removed dead `tauri://drop` listeners (window uses `dragDropEnabled: false`).

### New Download dialog refresh
- Bordered icon-badge header + footer, taller URL field, proper detected-file card.
- Start works immediately without waiting for the probe (size detected in the background).

## Verification
`tsc -b && vite build` green. Version bumped to 1.11.0 across all manifests; CHANGELOG updated.